### PR TITLE
remove verbose toolchain 'ky-toolchain-linux-glibc-x86_64-v1.0.1.tar.xz'

### DIFF
--- a/scripts/general.sh
+++ b/scripts/general.sh
@@ -1560,7 +1560,6 @@ prepare_host()
 			# download external Linaro compiler and missing special dependencies since they are needed for certain sources
 
 		local toolchains=(
-			"ky-toolchain-linux-glibc-x86_64-v1.0.1.tar.xz"
 			"gcc-linaro-aarch64-none-elf-4.8-2013.11_linux.tar.xz"
 			"gcc-linaro-arm-none-eabi-4.8-2014.04_linux.tar.xz"
 			"gcc-linaro-arm-linux-gnueabihf-4.8-2014.04_linux.tar.xz"
@@ -1683,11 +1682,6 @@ download_and_verify()
 
 	if [[ -f ${localdir}/${dirname}/.download-complete ]]; then
 		return
-	fi
-
-	if [[ ${filename} == *ky* ]]; then
-		server="http://www.iplaystore.cn/"
-		remotedir=""
 	fi
 
 	# switch to china mirror if US timeouts


### PR DESCRIPTION
Just remove the oudated and obsolete toochains.

```powershell
wget http://www.iplaystore.cn/ky-toolchain-linux-glibc-x86_64-v1.0.1.tar.xz
--2025-06-26 14:44:45--  http://www.iplaystore.cn/ky-toolchain-linux-glibc-x86_64-v1.0.1.tar.xz
Resolving www.iplaystore.cn (www.iplaystore.cn)... 123.57.154.183
Connecting to www.iplaystore.cn (www.iplaystore.cn)|123.57.154.183|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-06-26 14:44:45 ERROR 404: Not Found.
```

`ky-toolchain-linux-glibc-x86_64` was not in the package stored in the Baidu Netdisk.
![图片](https://github.com/user-attachments/assets/c3e1a561-afa2-4c70-972d-a1082707883d)
