### PR TITLE
Docker build:

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Git 相关文件
+.git
+.gitignore
+
+# IDE 配置文件
+.idea
+.vscode
+*.swp
+*.swo
+
+# 输出目录（避免复制到容器中）
+output/
+
+# 缓存文件
+*.cache
+__pycache__/
+
+# 文档文件
+README.md
+LICENSE
+
+# 其他不需要的文件
+.DS_Store
+Thumbs.db
+
+orangepi-output/
+docker-build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,12 @@ external/cache/sources/arm-trusted-firmware-2.2-hi3403
 external/cache/sources/arm-trusted-firmware-sunxi-mainline
 external/cache/debs/arm64/balenaEtcher-1.7.9+5945ab1f-arm64.AppImage
 external/cache/debs/arm64/balena-etcher-electron_1.7.9+5945ab1f_arm64.deb
+
+# output folder
+orangepi-output/
+
+# macosx
+.DS_Store
+
+# idea
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,153 @@
+FROM ubuntu:22.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get -y install \
+       joe \
+       software-properties-common \
+       gnupg \
+       gnupg1 \
+       gpgv1 \
+       curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN sh -c " \
+    if [ $(dpkg --print-architecture) = amd64 ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends \
+        lib32ncurses6 \
+        lib32stdc++6 \
+        lib32tinfo6 \
+        libc6-i386; \
+    fi"
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -y --no-install-recommends \
+       acl \
+       aptly \
+       aria2 \
+       bc \
+       binfmt-support \
+       binutils \
+       bison \
+       btrfs-progs \
+       build-essential \
+       ca-certificates \
+       ccache \
+       cpio \
+       cryptsetup \
+       cryptsetup-bin \
+       debian-archive-keyring \
+       debian-keyring \
+       debootstrap \
+       device-tree-compiler \
+       dialog \
+       distcc \
+       dosfstools \
+       dwarves \
+       f2fs-tools \
+       fakeroot \
+       fdisk \
+       flex \
+       gawk \
+       gcc-arm-linux-gnueabihf \
+       gcc-arm-linux-gnueabi \
+       gcc-arm-none-eabi \
+       gcc-riscv64-linux-gnu \
+       gdisk \
+       git \
+       imagemagick \
+       jq \
+       kmod \
+       libbison-dev \
+       libc6-amd64-cross \
+       libc6-dev-armhf-cross \
+       libc6-dev-riscv64-cross \
+       libfdt-dev \
+       libelf-dev \
+       libfile-fcntllock-perl \
+       libfl-dev \
+       liblz4-tool \
+       libncurses5-dev \
+       libpython2.7-dev \
+       libpython3-dev \
+       libssl-dev \
+       libusb-1.0-0-dev \
+       linux-base \
+       locales \
+       lsb-release \
+       lzop \
+       ncurses-base \
+       ncurses-term \
+       nfs-kernel-server \
+       ntpdate \
+       openssh-client \
+       p7zip-full \
+       parted \
+       patchutils \
+       pigz \
+       pixz \
+       pkg-config \
+       psmisc \
+       pv \
+       python2 \
+       python3 \
+       python3-dev \
+       python3-distutils \
+       python3-pkg-resources \
+       python3-setuptools \
+       rsync \
+       scons \
+       swig \
+       sudo \
+       systemd-container \
+       tzdata \
+       u-boot-tools \
+       udev \
+       unzip \
+       uuid \
+       uuid-dev \
+       uuid-runtime \
+       wget \
+       whiptail \
+       xfsprogs \
+       xxd \
+       zip \
+       zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN locale-gen en_US.UTF-8
+
+RUN git config --system --add safe.directory /root/orangepi
+
+# Static port for NFSv3 server used for USB FEL boot
+RUN sed -i 's/\(^STATDOPTS=\).*/\1"--port 32765 --outgoing-port 32766"/' /etc/default/nfs-common \
+    && sed -i 's/\(^RPCMOUNTDOPTS=\).*/\1"--port 32767"/' /etc/default/nfs-kernel-server
+
+RUN echo 'loop max_loop=128' >> /etc/modules
+
+# 创建loop设备初始化脚本
+RUN echo '#!/bin/bash' > /usr/local/bin/init-loop-devices && \
+    echo 'for i in $(seq 0 7); do' >> /usr/local/bin/init-loop-devices && \
+    echo '  if [ ! -e /dev/loop${i} ]; then' >> /usr/local/bin/init-loop-devices && \
+    echo '    mknod /dev/loop${i} b 7 ${i} 2>/dev/null || true' >> /usr/local/bin/init-loop-devices && \
+    echo '  fi' >> /usr/local/bin/init-loop-devices && \
+    echo 'done' >> /usr/local/bin/init-loop-devices && \
+    chmod +x /usr/local/bin/init-loop-devices
+
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8' TERM=screen
+WORKDIR /root/orangepi
+
+# 复制项目文件到容器中
+COPY build.sh /root/orangepi/build.sh
+COPY scripts/ /root/orangepi/scripts/
+COPY external/ /root/orangepi/external/
+
+# 创建output/debug目录用于挂载
+RUN mkdir -p /root/orangepi/output/debug
+
+# 设置执行权限
+RUN chmod +x /root/orangepi/build.sh
+
+LABEL org.opencontainers.image.source="https://github.com/orangepi-xunlong/orangepi-build/blob/main/external/config/templates/Dockerfile" \
+      org.opencontainers.image.authors="OrangePi Builder" \
+      org.opencontainers.image.licenses="GPL-2.0"
+
+# 启动时初始化loop设备
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/init-loop-devices && exec /root/orangepi/build.sh \"$@\"", "--"]

--- a/docker-build.md
+++ b/docker-build.md
@@ -1,0 +1,23 @@
+## Requirements
+
+### MacosX
+* Install docker-desktop
+* Enable "Use Rosetta for x86_64/amd64 emulation on Apple Silicon" in docker desktop setting
+
+### Windows
+
+## Build
+
+```shell
+# build docker image
+./docker-build.sh --build-image
+
+# build orangepi os image
+./docker-build.sh
+```
+
+## Output folders
+
+* Debug info - orangepi-output/debug
+* Image - orangepi-output/images (ex. orangepi-build/orangepi-output/images/Orangepi4pro_1.0.8_debian_bullseye_desktop_xfce_linux6.6.98/Orangepi4pro_1.0.8_debian_bullseye_desktop_xfce_linux6.6.98.img)
+* deb packages - orangepi-output/debs

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,225 @@
+d-#!/bin/bash
+
+# OrangePi Docker 构建脚本
+# 此脚本用于在Docker容器中构建OrangePi系统
+
+set -e
+
+# 颜色定义
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# 打印带颜色的消息
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 检查是否安装了Docker
+check_docker() {
+    if ! command -v docker &> /dev/null; then
+        print_error "Docker 未安装，请先安装Docker"
+        exit 1
+    fi
+    
+    # 检查Docker服务是否运行
+    if ! docker info &> /dev/null; then
+        print_error "Docker 服务未运行，请启动Docker服务"
+        exit 1
+    fi
+    
+    print_success "Docker 检查通过"
+}
+
+# 检查是否在Linux环境下运行
+check_environment() {
+    OS=$(uname -s)
+    if [ "$OS" != "Linux" ]; then
+        print_warning "宿主机系统: $OS"
+        print_warning "Docker Desktop 将在 Linux VM 中运行容器"
+        print_info "Loop 设备和镜像打包功能在 Docker Desktop 中可用"
+    else
+        print_success "运行环境检查通过 (Linux)"
+    fi
+    return 0
+}
+
+# 构建Docker镜像
+build_image() {
+    print_info "开始构建Docker镜像..."
+    
+    # 获取脚本所在目录
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    
+    # 构建Docker镜像，指定platform为amd64
+    docker build --platform linux/amd64 -t orangepi-build:latest "$SCRIPT_DIR"
+    
+    if [ $? -eq 0 ]; then
+        print_success "Docker镜像构建成功"
+    else
+        print_error "Docker镜像构建失败"
+        exit 1
+    fi
+}
+
+# 在Docker容器中运行构建
+run_build() {
+    print_info "在Docker容器中运行OrangePi构建..."
+    
+    # 获取脚本所在目录
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    
+    # 过滤掉docker-build.sh自己的选项，只保留传递给build.sh的参数
+    BUILD_PARAMS=()
+    for arg in "$@"; do
+        case $arg in
+            --build-image|--help|-h)
+                # 跳过docker-build.sh自己的选项
+                ;;
+            *)
+                BUILD_PARAMS+=("$arg")
+                ;;
+        esac
+    done
+    
+    # 运行Docker容器，指定platform为amd64
+    # 使用Docker volume保存构建产物和工具链
+    # 使用--privileged提供必要的权限用于loop设备操作
+    # 使用-u root确保以root用户运行
+    
+    # 检测操作系统类型
+    local HOST_OS=$(uname -s)
+    
+    # 如果存在同名容器，先删除
+    docker rm -f orangepi-build 2>/dev/null || true
+    
+    # 构建基础 Docker 参数
+    local DOCKER_ARGS=(
+        --platform linux/amd64
+        -it
+        --privileged
+        -u root
+        --device /dev/loop-control
+        --cap-add SYS_ADMIN
+        --cap-add MKNOD
+    )
+    
+    # 关于 /dev 挂载:
+    # - Linux: 可以直接挂载宿主机的 /dev
+    # - macOS/Windows (Docker Desktop): 不应该挂载 /dev，因为:
+    #   1. macOS 的 /dev 是 BSD 格式，与 Linux 不兼容
+    #   2. Windows 没有 /dev 概念
+    #   3. Docker Desktop 的 Linux VM 已经有完整的 /dev
+    #   4. --privileged 已经提供了足够的权限
+    if [ "$HOST_OS" = "Linux" ]; then
+        DOCKER_ARGS+=(-v /dev:/dev)
+        print_info "检测到 Linux 系统，已启用 /dev 挂载"
+    else
+        print_info "检测到 $HOST_OS 系统，使用 Docker Desktop Linux VM 的 /dev"
+        print_info "--privileged 模式已提供 loop 设备支持"
+    fi
+    
+    # 添加其他 volume 挂载
+    DOCKER_ARGS+=(
+        -v ./orangepi-output:/root/orangepi/output
+        -v orangepi-toolchains:/root/orangepi/toolchains
+        -v orangepi-kernel:/root/orangepi/kernel
+        -v orangepi-u-boot:/root/orangepi/u-boot
+        -v orangepi-tmp:/root/orangepi/.tmp
+        -v orangepi-sources:/root/orangepi/external/cache/sources
+        -w /root/orangepi
+        -e LANG=en_US.UTF-8
+        -e LANGUAGE=en_US:en
+        -e LC_ALL=en_US.UTF-8
+        -e TERM=xterm-256color
+        -e COLUMNS=120
+        -e LINES=30
+        -e NO_APT_CACHER=yes
+        --name orangepi-build
+    )
+    
+    if [ ${#BUILD_PARAMS[@]} -eq 0 ]; then
+        # 如果没有参数，启动交互式shell
+        docker run "${DOCKER_ARGS[@]}" orangepi-build:latest
+    else
+        # 如果有参数，执行构建
+        docker run "${DOCKER_ARGS[@]}" orangepi-build:latest "${BUILD_PARAMS[@]}"
+    fi
+}
+
+# 显示帮助信息
+show_help() {
+    echo "OrangePi Docker 构建脚本"
+    echo ""
+    echo "用法: $0 [选项] [构建参数]"
+    echo ""
+    echo "选项:"
+    echo "  --build-image    仅构建Docker镜像"
+    echo "  --help           显示此帮助信息"
+    echo ""
+    echo "示例:"
+    echo "  $0                    # 构建镜像并运行默认构建"
+    echo "  $0 --build-image      # 仅构建Docker镜像"
+    echo "  $0 BOARD=orangepizero2 BRANCH=current RELEASE=jammy BUILD_MINIMAL=yes"
+    echo ""
+    echo "注意: 构建参数将直接传递给OrangePi的build.sh脚本"
+}
+
+# 主函数
+main() {
+    # 解析命令行参数
+    BUILD_IMAGE_ONLY=false
+    
+    for arg in "$@"; do
+        case $arg in
+            --build-image)
+                BUILD_IMAGE_ONLY=true
+                shift
+                ;;
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            *)
+                # 保留其他参数用于构建
+                ;;
+        esac
+    done
+    
+    print_info "开始OrangePi Docker构建流程"
+    
+    # 检查环境
+    check_docker
+    check_environment
+    
+    # 构建Docker镜像
+    build_image
+
+    # 如果只需要构建镜像，则退出
+    if [ "$BUILD_IMAGE_ONLY" = true ]; then
+        print_success "Docker镜像构建完成"
+        exit 0
+    fi
+    
+    # 运行构建
+    run_build "$@"
+    
+    print_success "OrangePi构建完成"
+}
+
+# 执行主函数
+main "$@"

--- a/external/config/sources/families/sun60iw2.conf
+++ b/external/config/sources/families/sun60iw2.conf
@@ -121,7 +121,9 @@ family_tweaks_s()
 	if [[ $RELEASE =~ bullseye && ${SELECTED_CONFIGURATION} == desktop ]]; then
 		local packages_dir="$EXTER/cache/sources/sun60iw2_packages"
 		#local packages_to_install=("xserver" "glmark2" "libcedarc" "gst-omx")
-		local packages_to_install=("libAWIspApi" "glmark2" "libcedarc" "gst-omx-generic1.0" "gstreamer1.0-plugins-good" "vlc")
+
+		# lvc安装会失败，这里先删掉vlc
+		local packages_to_install=("libAWIspApi" "glmark2" "libcedarc" "gst-omx-generic1.0" "gstreamer1.0-plugins-good")
 		chroot $SDCARD /bin/bash -c "apt-get -y -qq install gstreamer1.0-x gstreamer1.0-plugins-bad gstreamer1.0-alsa" >> "${DEST}"/${LOG_SUBPATH}/install.log 2>&1
 
 		cp -rf ${packages_dir}/bullseye/xserver/xserver-xorg-img-bxm_1.21.1-2_arm64.deb ${SDCARD}/

--- a/scripts/configuration.sh
+++ b/scripts/configuration.sh
@@ -183,6 +183,14 @@ show_menu() {
 	#echo "Provided menuname : $provided_menuname"
 	#echo "Provided options : " "${@:4}"
 	#echo "TTY X: $TTY_X Y: $TTY_Y"
+	
+	# Validate TTY values before calling whiptail
+	if [[ -z "$TTY_X" || -z "$TTY_Y" || "$TTY_X" -lt 40 || "$TTY_Y" -lt 10 ]]; then
+		echo "Warning: Invalid TTY dimensions (X=$TTY_X, Y=$TTY_Y), using defaults" >&2
+		TTY_X=80
+		TTY_Y=24
+	fi
+	
 	whiptail --title "${provided_title}" --backtitle "${provided_backtitle}" --notags \
                           --menu "${provided_menuname}" "${TTY_Y}" "${TTY_X}" $((TTY_Y - 8))  \
 			  "${@:4}" \
@@ -201,6 +209,13 @@ show_select_menu() {
 	#                  --checklist "${provided_menuname}" "${TTY_Y}" "${TTY_X}" $((TTY_Y - 8))  \
 	#		  "${@:4}" \
 	#		  3>&1 1>&2 2>&3
+
+	# Validate TTY values before calling whiptail
+	if [[ -z "$TTY_X" || -z "$TTY_Y" || "$TTY_X" -lt 40 || "$TTY_Y" -lt 10 ]]; then
+		echo "Warning: Invalid TTY dimensions (X=$TTY_X, Y=$TTY_Y), using defaults" >&2
+		TTY_X=80
+		TTY_Y=24
+	fi
 
 	whiptail --title "${provided_title}" --backtitle "${provided_backtitle}" \
 	                  --checklist "${provided_menuname}" "${TTY_Y}" "${TTY_X}" $((TTY_Y - 8))  \

--- a/scripts/debootstrap.sh
+++ b/scripts/debootstrap.sh
@@ -651,6 +651,14 @@ PREPARE_IMAGE_SIZE
 	check_loop_device "$LOOP"
 
 	losetup -P $LOOP ${SDCARD}.raw
+	
+	# 在Docker容器中,需要显式触发分区表扫描
+	if [[ $(systemd-detect-virt) == 'docker' ]]; then
+		display_alert "Scanning partition table" "$LOOP" "info"
+		partprobe "$LOOP" 2>/dev/null || true
+		# 等待设备节点创建
+		sleep 1
+	fi
 
 	# loop device was grabbed here, unlock
 	flock -u $FD

--- a/scripts/image-helpers.sh
+++ b/scripts/image-helpers.sh
@@ -105,7 +105,39 @@ check_loop_device()
 			display_alert "Creating device node" "$device"
 			mknod -m0660 "${device}" b "0x$(stat -c '%t' "/tmp/$device")" "0x$(stat -c '%T' "/tmp/$device")"
 		else
-			exit_with_error "Device node $device does not exist"
+			# 在Docker中等待设备节点创建
+			if [[ $(systemd-detect-virt) == 'docker' ]]; then
+				display_alert "Waiting for device node" "$device" "info"
+				local retries=5
+				while [[ $retries -gt 0 ]]; do
+					sleep 1
+					[[ -b $device ]] && break
+					retries=$((retries - 1))
+					display_alert "Retrying..." "$retries attempts left" "info"
+				done
+				
+				# 如果仍然不存在，尝试手动创建（Docker 容器中 udev 可能未运行）
+				if [[ ! -b $device ]]; then
+					display_alert "Device node not created by udev, creating manually" "$device" "wrn"
+					local base_device=$(echo "$device" | sed 's/p[0-9]*$//')
+					local part_num=$(echo "$device" | grep -o 'p[0-9]*$' | sed 's/p//')
+					
+					# 从 /proc/partitions 获取设备号
+					if grep -q "$(basename $device)" /proc/partitions 2>/dev/null; then
+						local major=$(awk -v dev="$(basename $device)" '$4==dev{print $1}' /proc/partitions)
+						local minor=$(awk -v dev="$(basename $device)" '$4==dev{print $2}' /proc/partitions)
+						
+						if [[ -n $major && -n $minor ]]; then
+							display_alert "Creating device node manually" "$device (major=$major, minor=$minor)" "info"
+							mknod -m0660 "$device" b $major $minor 2>/dev/null || true
+						fi
+					fi
+				fi
+			fi
+			
+			if [[ ! -b $device ]]; then
+				exit_with_error "Device node $device does not exist"
+			fi
 		fi
 	fi
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -50,8 +50,18 @@ if [[ $BUILD_ALL != "yes" ]]; then
 	# override stty size
 	[[ -n $COLUMNS ]] && stty cols $COLUMNS
 	[[ -n $LINES ]] && stty rows $LINES
-	TTY_X=$(($(stty size | awk '{print $2}')-6)) 			# determine terminal width
-	TTY_Y=$(($(stty size | awk '{print $1}')-6)) 			# determine terminal height
+	# Check if stty is available (may fail in non-interactive Docker)
+	if stty size > /dev/null 2>&1; then
+		TTY_X=$(($(stty size | awk '{print $2}')-6)) 			# determine terminal width
+		TTY_Y=$(($(stty size | awk '{print $1}')-6)) 			# determine terminal height
+	else
+		# Fallback to environment variables or defaults for Docker/non-interactive environments
+		TTY_X=${COLUMNS:-120}
+		TTY_Y=${LINES:-30}
+	fi
+	# Ensure TTY values are reasonable (whiptail needs positive values)
+	[[ $TTY_X -lt 40 ]] && TTY_X=80
+	[[ $TTY_Y -lt 10 ]] && TTY_Y=24
 fi
 
 # We'll use this title on all menus


### PR DESCRIPTION
- Build orangepi-os with docker
- Had tested build on macbook pro m4
- Had tested build OrangePi 3b, 4pro, 5max, zerow2, zerow3, 6plus

备注：

- 使用amd64架构ubuntu docker镜像
- 测试过OrangePi 3b, 4pro, 5max, zerow2, zerow3, 6plus的镜像构建
- 测试过zero3w，和pro4两块开发板上运行镜像，手头只有这两个
- 如果觉得有价值可以merge或者参考这个PR建新commit都没问题
- local packages_to_install=("libAWIspApi" "glmark2" "libcedarc" "gst-omx-generic1.0" "gstreamer1.0-plugins-good", "vlc")， 去掉了"vlc"是因为在很多不同环境测试这个安装都失败
- 另外关于wsl上的构建，只能在原生的linux文件系统上，不能用ntfs，否则会出现文件名大小写不一致的错误， 我测试过WSL上构建是没问题的
    ```shell
	    if grep -qE "(Microsoft|WSL)" /proc/version; then
		    if [ -f /.dockerenv ]; then
			    display_alert "Building images using Docker on WSL2 may fail" "" "wrn"
		    else
			    exit_with_error "Windows subsystem for Linux is not a supported build environment"
		    fi
	    fi
    ``` 
感觉 这一段的检查里 加上文件系统类型的检查就可以了
- 我在wsl中关闭了windows path， 没有测试是否有影响，但是关闭之后构建是肯定可以成功的
```shel
sudo tee /etc/wsl.conf >/dev/null <<'EOF'
[interop]
appendWindowsPath = false
EOF
```


只能在amd64的ubuntu22.04上构建不方便，希望官方构建能支持docker和wsl